### PR TITLE
Correction of modulo and exponent : cannot be negative so use another

### DIFF
--- a/src/main/java/net/oauth/jsontoken/crypto/MagicRsaPublicKey.java
+++ b/src/main/java/net/oauth/jsontoken/crypto/MagicRsaPublicKey.java
@@ -65,8 +65,8 @@ public class MagicRsaPublicKey {
     byte[] modulusBytes = Base64.decodeBase64(modulusString);
     byte[] exponentBytes = Base64.decodeBase64(exponentString);
 
-    BigInteger modulus = new BigInteger(modulusBytes);
-    BigInteger exponent = new BigInteger(exponentBytes);
+    BigInteger modulus = new BigInteger(1, modulusBytes);
+    BigInteger exponent = new BigInteger(1, exponentBytes);
 
     RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
     KeyFactory fac;


### PR DESCRIPTION
Correction of modulo and exponent : cannot be negative so use another constructor of BigInteger to be confident in the result