### PR TITLE
replaced google-collections with guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,13 +85,13 @@
     	<type>jar</type>
     	<scope>compile</scope>
     </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>20.0</version>
-          <type>jar</type>
-          <scope>compile</scope>
-      </dependency>
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>20.0</version>
+        <type>jar</type>
+        <scope>compile</scope>
+    </dependency>
     <dependency>
     	<groupId>joda-time</groupId>
     	<artifactId>joda-time</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,13 +85,13 @@
     	<type>jar</type>
     	<scope>compile</scope>
     </dependency>
-    <dependency>
-    	<groupId>com.google.collections</groupId>
-    	<artifactId>google-collections</artifactId>
-    	<version>1.0</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
-    </dependency>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>20.0</version>
+          <type>jar</type>
+          <scope>compile</scope>
+      </dependency>
     <dependency>
     	<groupId>joda-time</groupId>
     	<artifactId>joda-time</artifactId>


### PR DESCRIPTION
It seems like some people/projects still want to use jsontoken to generate the token, but they introduce this incompatibility with guava. With a little luck, a JAR Hell appears.

Issue for this thing: this: https://github.com/google/jsontoken/issues/8
