### PR TITLE
Add additional unit tests for JsonTokenParser and rename some existing tests

### DIFF
--- a/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
@@ -58,7 +58,6 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
 
     JsonTokenParser parser = new JsonTokenParser(clock, locators, new IgnoreAudience());
     JsonToken checkToken = parser.deserialize(token.serializeAndSign());
-
     try {
       parser.verify(checkToken);
       return true;
@@ -126,7 +125,6 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
   private boolean testVerifySignature(String tokenString) throws Exception {
     JsonTokenParser parser = new JsonTokenParser(clock, locators, new IgnoreAudience());
     JsonToken checkToken = parser.deserialize(tokenString);
-
     try {
       parser.verify(checkToken);
       return true;

--- a/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
@@ -176,7 +176,7 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
     assertEquals(SignatureAlgorithm.HS256, token.getSignatureAlgorithm());
     assertEquals("key2", token.getKeyId());
     assertEquals(new Instant(1276669722000L), token.getIssuedAt());
-    assertEquals(new Instant(1276669722000L), token.getExpiration());
+    assertEquals(new Instant(1276669723000L), token.getExpiration());
     assertEquals(15, token.getParamAsPrimitive("bar").getAsLong());
     assertEquals("some value", token.getParamAsPrimitive("foo").getAsString());
   }
@@ -239,7 +239,7 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
     assertEquals(SignatureAlgorithm.HS256, token.getSignatureAlgorithm());
     assertEquals("key2", token.getKeyId());
     assertEquals(new Instant(1276669722000L), token.getIssuedAt());
-    assertEquals(new Instant(1276669722000L), token.getExpiration());
+    assertEquals(new Instant(1276669723000L), token.getExpiration());
     assertEquals(15, token.getParamAsPrimitive("bar").getAsLong());
     assertEquals("some value", token.getParamAsPrimitive("foo").getAsString());
   }

--- a/src/test/java/net/oauth/jsontoken/JsonTokenTest.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenTest.java
@@ -1,6 +1,7 @@
 package net.oauth.jsontoken;
 
 import net.oauth.jsontoken.crypto.HmacSHA256Signer;
+import org.joda.time.Duration;
 
 public class JsonTokenTest extends JsonTokenTestBase {
 
@@ -12,7 +13,7 @@ public class JsonTokenTest extends JsonTokenTestBase {
     token.setParam("foo", "some value");
     token.setAudience("http://www.google.com");
     token.setIssuedAt(clock.now());
-    token.setExpiration(clock.now().withDurationAdded(60, 1));
+    token.setExpiration(clock.now().plus(Duration.standardSeconds(1)));
 
     assertEquals(TOKEN_STRING, token.serializeAndSign());
   }

--- a/src/test/java/net/oauth/jsontoken/JsonTokenTestBase.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenTestBase.java
@@ -82,7 +82,7 @@ public abstract class JsonTokenTestBase extends TestCase {
   protected VerifierProviders locatorsFromRuby;
   protected RSAPrivateKey privateKey;
 
-  protected static String TOKEN_STRING = "eyJhbGciOiJIUzI1NiIsImtpZCI6ImtleTIifQ.eyJpc3MiOiJnb29nbGUuY29tIiwiYmFyIjoxNSwiZm9vIjoic29tZSB2YWx1ZSIsImF1ZCI6Imh0dHA6Ly93d3cuZ29vZ2xlLmNvbSIsImlhdCI6MTI3NjY2OTcyMiwiZXhwIjoxMjc2NjY5NzIyfQ.jKcuP6BR_-cKpQv2XdFLguYgOxw4ahkZiqjcgrQcm70";
+  protected static final String TOKEN_STRING = "eyJhbGciOiJIUzI1NiIsImtpZCI6ImtleTIifQ.eyJpc3MiOiJnb29nbGUuY29tIiwiYmFyIjoxNSwiZm9vIjoic29tZSB2YWx1ZSIsImF1ZCI6Imh0dHA6Ly93d3cuZ29vZ2xlLmNvbSIsImlhdCI6MTI3NjY2OTcyMiwiZXhwIjoxMjc2NjY5NzIzfQ.Xugb4nb5kLV3NTpOLaz9er5PhAI5mFehHst_33EUFHs";
   protected static final Duration SKEW = Duration.standardMinutes(1);
   protected FakeClock clock = new FakeClock(SKEW);
 


### PR DESCRIPTION
There are additional unit tests that will test more thoroughly the public functions of JsonTokenParser. Specifically, there are now unit tests for `issuedAtIsValid`, `expirationIsValid`, `signatureIsValid`. Also, for some of the old tests, I split them up so they test one thing at a time. For example, some of the existing tests use `verifyAndDeserialize` when only `verify` is needed to be tested (see `checkTimeFrame` in the old tests). I renamed some of the existing tests to better reflect what they are testing as well. Currently, two tests are failing because of the bug with `getKeyId`. This will be fixed after this PR (https://github.com/google/jsontoken/pull/22) is finalized and merged.