### PR TITLE
Fix Parser Splitting Token Bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,9 @@
     	<scope>compile</scope>
     </dependency>
     <dependency>
-    	<groupId>com.google.collections</groupId>
-    	<artifactId>google-collections</artifactId>
-    	<version>1.0</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
+    	<groupId>com.google.guava</groupId>
+    	<artifactId>guava</artifactId>
+    	<version>29.0-jre</version>
     </dependency>
     <dependency>
     	<groupId>joda-time</groupId>

--- a/src/main/java/net/oauth/jsontoken/JsonTokenParser.java
+++ b/src/main/java/net/oauth/jsontoken/JsonTokenParser.java
@@ -17,22 +17,18 @@
 package net.oauth.jsontoken;
 
 import com.google.common.base.Preconditions;
-import com.google.gson.JsonElement;
+import com.google.common.base.Splitter;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
-
 import net.oauth.jsontoken.crypto.AsciiStringVerifier;
 import net.oauth.jsontoken.crypto.SignatureAlgorithm;
 import net.oauth.jsontoken.crypto.Verifier;
 import net.oauth.jsontoken.discovery.VerifierProviders;
-
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.Instant;
-
 import java.security.SignatureException;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Class that parses and verifies JSON Tokens.
@@ -257,11 +253,11 @@ public class JsonTokenParser {
    * @throws IllegalStateException if tokenString is not a properly formatted JWT
    */
   private String[] splitTokenString(String tokenString) {
-    String[] pieces = tokenString.split(Pattern.quote(JsonTokenUtil.DELIMITER));
-    if (pieces.length != 3) {
+    List<String> pieces = Splitter.on(JsonTokenUtil.DELIMITER).limit(4).splitToList(tokenString);
+    if (pieces.size() != 3) {
       throw new IllegalStateException("Expected JWT to have 3 segments separated by '" + 
-          JsonTokenUtil.DELIMITER + "', but it has " + pieces.length + " segments");
+          JsonTokenUtil.DELIMITER + "', but it has " + pieces.size() + " segments");
     }
-    return pieces;
+    return pieces.toArray(new String[0]);
   }
 }

--- a/src/main/java/net/oauth/jsontoken/JsonTokenParser.java
+++ b/src/main/java/net/oauth/jsontoken/JsonTokenParser.java
@@ -76,10 +76,9 @@ public class JsonTokenParser {
    * @throws IllegalStateException if tokenString is not a properly formatted JWT
    */
   public JsonToken deserialize(String tokenString) {
-    String[] pieces = splitTokenString(tokenString);
-    String jwtHeaderSegment = pieces[0];
-    String jwtPayloadSegment = pieces[1];
-    byte[] signature = Base64.decodeBase64(pieces[2]);
+    List<String> pieces = splitTokenString(tokenString);
+    String jwtHeaderSegment = pieces.get(0);
+    String jwtPayloadSegment = pieces.get(1);
     JsonParser parser = new JsonParser();
     JsonObject header = parser.parse(JsonTokenUtil.fromBase64ToJsonString(jwtHeaderSegment))
         .getAsJsonObject();
@@ -178,9 +177,9 @@ public class JsonTokenParser {
    * @throws IllegalStateException if tokenString is not a properly formatted JWT
    */
   public boolean signatureIsValid(String tokenString, List<Verifier> verifiers) {
-    String[] pieces = splitTokenString(tokenString);
-    byte[] signature = Base64.decodeBase64(pieces[2]);
-    String baseString = JsonTokenUtil.toDotFormat(pieces[0], pieces[1]);
+    List<String> pieces = splitTokenString(tokenString);
+    byte[] signature = Base64.decodeBase64(pieces.get(2));
+    String baseString = JsonTokenUtil.toDotFormat(pieces.get(0), pieces.get(1));
 
     boolean sigVerified = false;
     for (Verifier verifier : verifiers) {
@@ -252,12 +251,12 @@ public class JsonTokenParser {
    * @return Three components of the JWT as an array of strings
    * @throws IllegalStateException if tokenString is not a properly formatted JWT
    */
-  private String[] splitTokenString(String tokenString) {
-    List<String> pieces = Splitter.on(JsonTokenUtil.DELIMITER).limit(4).splitToList(tokenString);
+  private List<String> splitTokenString(String tokenString) {
+    List<String> pieces = Splitter.on(JsonTokenUtil.DELIMITER).splitToList(tokenString);
     if (pieces.size() != 3) {
       throw new IllegalStateException("Expected JWT to have 3 segments separated by '" + 
           JsonTokenUtil.DELIMITER + "', but it has " + pieces.size() + " segments");
     }
-    return pieces.toArray(new String[0]);
+    return pieces;
   }
 }

--- a/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
@@ -136,10 +136,7 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
 
   public void testDeserialize_emptySignature() throws Exception {
     JsonTokenParser parser = new JsonTokenParser(clock, locators, new IgnoreAudience());
-    assertThrows(
-        IllegalStateException.class,
-        () -> parser.deserialize(TOKEN_STRING_EMPTY_SIG)
-    );
+    parser.deserialize(TOKEN_STRING_EMPTY_SIG);
   }
 
   public void testDeserialize_corruptHeader() throws Exception {


### PR DESCRIPTION
There is a bug with `splitTokenString` where trailing delimiters are ignored because of the behavior of `split` (https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#split-java.lang.String-). This would allow for the case where a token string like `a.b.c.............` is viewed the same as `a.b.c`. We fix this by using Guava's Splitter utility to parse the token string.