### PR TITLE
Code and import cleanup on relevant classes

### DIFF
--- a/src/main/java/net/oauth/jsontoken/AbstractJsonTokenParser.java
+++ b/src/main/java/net/oauth/jsontoken/AbstractJsonTokenParser.java
@@ -21,12 +21,12 @@ import com.google.common.base.Splitter;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import java.security.SignatureException;
+import java.util.List;
 import net.oauth.jsontoken.crypto.AsciiStringVerifier;
 import net.oauth.jsontoken.crypto.Verifier;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.Instant;
-import java.security.SignatureException;
-import java.util.List;
 
 /**
  * Class that provides common functions

--- a/src/main/java/net/oauth/jsontoken/Checker.java
+++ b/src/main/java/net/oauth/jsontoken/Checker.java
@@ -17,7 +17,6 @@
 package net.oauth.jsontoken;
 
 import com.google.gson.JsonObject;
-
 import java.security.SignatureException;
 
 /**
@@ -31,6 +30,6 @@ public interface Checker {
    * @param payload the payload component of a JsonToken (JWT)
    * @throws SignatureException if the audience doesn't match.
    */
-  public void check(JsonObject payload) throws SignatureException;
+  void check(JsonObject payload) throws SignatureException;
 
 }

--- a/src/main/java/net/oauth/jsontoken/Clock.java
+++ b/src/main/java/net/oauth/jsontoken/Clock.java
@@ -26,12 +26,12 @@ public interface Clock {
   /**
    * Returns current time.
    */
-  public Instant now();
+  Instant now();
 
   /**
    * Determines whether the current time falls within the interval defined by the
    * start and intervalLength parameters. Implementations are free to fudge this a
    * little bit to take into account possible clock skew.
    */
-  public boolean isCurrentTimeInInterval(Instant start, Instant end);
+  boolean isCurrentTimeInInterval(Instant start, Instant end);
 }

--- a/src/main/java/net/oauth/jsontoken/JsonToken.java
+++ b/src/main/java/net/oauth/jsontoken/JsonToken.java
@@ -20,17 +20,13 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-
+import java.security.SignatureException;
+import javax.annotation.Nullable;
 import net.oauth.jsontoken.crypto.AsciiStringSigner;
 import net.oauth.jsontoken.crypto.SignatureAlgorithm;
 import net.oauth.jsontoken.crypto.Signer;
-
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.Instant;
-
-import javax.annotation.Nullable;
-import java.security.SignatureException;
-
 
 /**
  * A JSON Token.

--- a/src/main/java/net/oauth/jsontoken/JsonTokenParser.java
+++ b/src/main/java/net/oauth/jsontoken/JsonTokenParser.java
@@ -19,10 +19,10 @@ package net.oauth.jsontoken;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import net.oauth.jsontoken.crypto.Verifier;
-import net.oauth.jsontoken.discovery.VerifierProviders;
 import java.security.SignatureException;
 import java.util.List;
+import net.oauth.jsontoken.crypto.Verifier;
+import net.oauth.jsontoken.discovery.VerifierProviders;
 
 /**
  * Class that parses and verifies JSON Tokens.

--- a/src/main/java/net/oauth/jsontoken/discovery/VerifierProvider.java
+++ b/src/main/java/net/oauth/jsontoken/discovery/VerifierProvider.java
@@ -16,10 +16,9 @@
  */
 package net.oauth.jsontoken.discovery;
 
+import java.util.List;
 import net.oauth.jsontoken.JsonTokenParser;
 import net.oauth.jsontoken.crypto.Verifier;
-
-import java.util.List;
 
 /**
  * An interface that must be implemented by JSON Token verifiers. The {@link JsonTokenParser}
@@ -34,13 +33,13 @@ import java.util.List;
 public interface VerifierProvider {
 
   /**
-   * Returns the {@link Verifier} that represents a certain verification
+   * Returns the {@link List<Verifier>} that represents a certain verification
    * key, given the key's id and its issuer.
    * @param issuer the id of the issuer that's using the key.
    * @param keyId the id of the key, if keyId mismatches, return a list of 
    * possible verification keys.
-   * @return a {@link Verifier} object that represents the verification key.
+   * @return a {@link List<Verifier>} object that represents the verification key.
    */
-  public List<Verifier> findVerifier(String issuer, String keyId);
+  List<Verifier> findVerifier(String issuer, String keyId);
 
 }

--- a/src/main/java/net/oauth/jsontoken/discovery/VerifierProviders.java
+++ b/src/main/java/net/oauth/jsontoken/discovery/VerifierProviders.java
@@ -16,10 +16,9 @@
  */
 package net.oauth.jsontoken.discovery;
 
-import java.util.Map;
-
 import com.google.common.collect.Maps;
-
+import java.util.List;
+import java.util.Map;
 import net.oauth.jsontoken.JsonTokenParser;
 import net.oauth.jsontoken.crypto.SignatureAlgorithm;
 import net.oauth.jsontoken.crypto.Verifier;
@@ -32,7 +31,7 @@ import net.oauth.jsontoken.crypto.Verifier;
  * will use different ways to look up verification keys - for example, symmetric keys
  * will always be pre-negotiated and looked up in a local database, while public
  * verification keys can be looked up on demand), and the ask the {@link VerifierProvider}
- * to provide a {@link Verifier} to check the validity of the JSON Token.
+ * to provide a {@link List<Verifier>} to check the validity of the JSON Token.
  */
 public class VerifierProviders {
 

--- a/src/test/java/net/oauth/jsontoken/AbstractJsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/AbstractJsonTokenParserTest.java
@@ -136,7 +136,7 @@ public class AbstractJsonTokenParserTest extends JsonTokenTestBase {
 
   public void testVerify_failChecker() throws Exception {
     AbstractJsonTokenParser parser =
-        getAbstractJsonTokenParser(new IgnoreAudience(), new AlwaysFailAudience());
+        getAbstractJsonTokenParser(new AlwaysPassChecker(), new AlwaysFailChecker());
     JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
     assertThrows(
         SignatureException.class,
@@ -181,7 +181,7 @@ public class AbstractJsonTokenParserTest extends JsonTokenTestBase {
   }
 
   public void testDeserialize_emptySignature() throws Exception {
-    JsonTokenParser parser = new JsonTokenParser(clock, locators, new IgnoreAudience());
+    JsonTokenParser parser = new JsonTokenParser(clock, locators, new AlwaysPassChecker());
     parser.deserialize(TOKEN_STRING_EMPTY_SIG);
   }
 
@@ -317,7 +317,7 @@ public class AbstractJsonTokenParserTest extends JsonTokenTestBase {
   }
 
   private AbstractJsonTokenParser getAbstractJsonTokenParser() {
-    return new AbstractJsonTokenParser(clock, new IgnoreAudience()){};
+    return new AbstractJsonTokenParser(clock, new AlwaysPassChecker()){};
   }
 
   private AbstractJsonTokenParser getAbstractJsonTokenParser(Checker... checkers) {

--- a/src/test/java/net/oauth/jsontoken/AlwaysFailChecker.java
+++ b/src/test/java/net/oauth/jsontoken/AlwaysFailChecker.java
@@ -6,7 +6,7 @@ import java.security.SignatureException;
 /**
  * Fails on any audience (even null).
  */
-public class AlwaysFailAudience implements Checker {
+public final class AlwaysFailChecker implements Checker {
 
   @Override
   public void check(JsonObject payload) throws SignatureException {

--- a/src/test/java/net/oauth/jsontoken/AlwaysPassChecker.java
+++ b/src/test/java/net/oauth/jsontoken/AlwaysPassChecker.java
@@ -17,13 +17,12 @@
 package net.oauth.jsontoken;
 
 import com.google.gson.JsonObject;
-
 import java.security.SignatureException;
 
 /**
  * Allows any audience (even null).
  */
-public class IgnoreAudience implements Checker {
+public final class AlwaysPassChecker implements Checker {
 
   @Override
   public void check(JsonObject payload) throws SignatureException {

--- a/src/test/java/net/oauth/jsontoken/AsyncJsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/AsyncJsonTokenParserTest.java
@@ -82,7 +82,7 @@ public class AsyncJsonTokenParserTest extends JsonTokenTestBase {
       return null;
     };
 
-    AsyncJsonTokenParser parser = getAsyncJsonTokenParser(noLocators, new IgnoreAudience());
+    AsyncJsonTokenParser parser = getAsyncJsonTokenParser(noLocators, new AlwaysPassChecker());
     JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
     assertFailsWithCause(
         IllegalStateException.class,
@@ -115,7 +115,7 @@ public class AsyncJsonTokenParserTest extends JsonTokenTestBase {
 
   public void testVerifyAndDeserialize_tokenFromRuby() throws Exception {
     AsyncJsonTokenParser parser =
-        getAsyncJsonTokenParser(asyncLocatorsFromRuby, new IgnoreAudience());
+        getAsyncJsonTokenParser(asyncLocatorsFromRuby, new AlwaysPassChecker());
     JsonToken token = parser.verifyAndDeserialize(TOKEN_FROM_RUBY).get();
 
     assertEquals(SignatureAlgorithm.HS256, token.getSignatureAlgorithm());
@@ -124,7 +124,7 @@ public class AsyncJsonTokenParserTest extends JsonTokenTestBase {
   }
 
   private AsyncJsonTokenParser getAsyncJsonTokenParser() {
-    return new AsyncJsonTokenParser(clock, asyncLocators, executor, new IgnoreAudience());
+    return new AsyncJsonTokenParser(clock, asyncLocators, executor, new AlwaysPassChecker());
   }
 
   private AsyncJsonTokenParser getAsyncJsonTokenParser(

--- a/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
@@ -53,7 +53,7 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
     VerifierProviders noLocators = new VerifierProviders();
     noLocators.setVerifierProvider(SignatureAlgorithm.HS256, noLocator);
 
-    JsonTokenParser parser = getJsonTokenParser(noLocators, new IgnoreAudience());
+    JsonTokenParser parser = getJsonTokenParser(noLocators, new AlwaysPassChecker());
     JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
     assertThrows(
         IllegalStateException.class,
@@ -85,7 +85,7 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
   }
 
   public void testVerifyAndDeserialize_tokenFromRuby() throws Exception {
-    JsonTokenParser parser = getJsonTokenParser(locatorsFromRuby, new IgnoreAudience());
+    JsonTokenParser parser = getJsonTokenParser(locatorsFromRuby, new AlwaysPassChecker());
     JsonToken token = parser.verifyAndDeserialize(TOKEN_FROM_RUBY);
 
     assertEquals(SignatureAlgorithm.HS256, token.getSignatureAlgorithm());
@@ -131,7 +131,7 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
   }
 
   private JsonTokenParser getJsonTokenParser() {
-    return new JsonTokenParser(clock, locators, new IgnoreAudience());
+    return new JsonTokenParser(clock, locators, new AlwaysPassChecker());
   }
 
   private JsonTokenParser getJsonTokenParser(VerifierProviders providers, Checker... checkers) {


### PR DESCRIPTION
Clean up imports, documentation, and class naming for files relevant to changes in the files directly related to sync and async parsers. Address the review (https://github.com/google/jsontoken/pull/34#discussion_r443076191) that didn't get merged with the PR.