### PR TITLE
Fix NPE bug in sync provideVerifiers, Update tests for both sync and async to reflect the behavior

### DIFF
--- a/src/main/java/net/oauth/jsontoken/discovery/VerifierProviders.java
+++ b/src/main/java/net/oauth/jsontoken/discovery/VerifierProviders.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 
+import javax.annotation.Nullable;
 import net.oauth.jsontoken.JsonTokenParser;
 import net.oauth.jsontoken.crypto.SignatureAlgorithm;
 import net.oauth.jsontoken.crypto.Verifier;
@@ -48,6 +49,7 @@ public class VerifierProviders {
   /**
    * Returns the {@link VerifierProvider} for the given {@link SignatureAlgorithm}.
    */
+  @Nullable
   public VerifierProvider getVerifierProvider(SignatureAlgorithm alg) {
     return map.get(alg);
   }

--- a/src/main/java/net/oauth/jsontoken/discovery/VerifierProviders.java
+++ b/src/main/java/net/oauth/jsontoken/discovery/VerifierProviders.java
@@ -17,12 +17,10 @@
 package net.oauth.jsontoken.discovery;
 
 import com.google.common.collect.Maps;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.oauth.jsontoken.JsonTokenParser;
 import net.oauth.jsontoken.crypto.SignatureAlgorithm;
-import net.oauth.jsontoken.crypto.Verifier;
 
 /**
  * A collection of {@link VerifierProvider}s, one for each signature algorithm.
@@ -32,7 +30,7 @@ import net.oauth.jsontoken.crypto.Verifier;
  * will use different ways to look up verification keys - for example, symmetric keys
  * will always be pre-negotiated and looked up in a local database, while public
  * verification keys can be looked up on demand), and the ask the {@link VerifierProvider}
- * to provide a {@link List <Verifier>} to check the validity of the JSON Token.
+ * to provide a {@code List<Verifier>} to check the validity of the JSON Token.
  */
 public class VerifierProviders {
 

--- a/src/test/java/net/oauth/jsontoken/AsyncJsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/AsyncJsonTokenParserTest.java
@@ -81,11 +81,22 @@ public class AsyncJsonTokenParserTest extends JsonTokenTestBase {
       }
       return null;
     };
-
     AsyncJsonTokenParser parser = getAsyncJsonTokenParser(noLocators, new IgnoreAudience());
     JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
+
     assertFailsWithCause(
         IllegalStateException.class,
+        () -> parser.verify(checkToken).get()
+    );
+  }
+
+  public void testVerify_noProviders() throws Exception {
+    AsyncVerifierProviders noProviders = alg -> null;
+    AsyncJsonTokenParser parser = getAsyncJsonTokenParser(noProviders, new IgnoreAudience());
+    JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
+
+    assertFailsWithCause(
+        IllegalArgumentException.class,
         () -> parser.verify(checkToken).get()
     );
   }

--- a/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
+++ b/src/test/java/net/oauth/jsontoken/JsonTokenParserTest.java
@@ -55,8 +55,20 @@ public class JsonTokenParserTest extends JsonTokenTestBase {
 
     JsonTokenParser parser = getJsonTokenParser(noLocators, new IgnoreAudience());
     JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
+
     assertThrows(
         IllegalStateException.class,
+        () -> parser.verify(checkToken)
+    );
+  }
+
+  public void testVerify_noProviders() throws Exception {
+    VerifierProviders noProviders = new VerifierProviders();
+    JsonTokenParser parser = getJsonTokenParser(noProviders, new IgnoreAudience());
+    JsonToken checkToken = naiveDeserialize(TOKEN_STRING);
+
+    assertThrows(
+        IllegalArgumentException.class,
         () -> parser.verify(checkToken)
     );
   }


### PR DESCRIPTION
Update sync provideVerifiers function to check for null providers. Throw IllegalArgumentException if there is. Update unit tests for both sync and async to add additional documentation for this behavior. 